### PR TITLE
fix: prevent deletion of the last project in Log Analysis Beta menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "log-analysis-beta" extension will be documented in this file.
 
+## 1.2.14
+
+- Fixed issue [#3](https://github.com/JeanTracker/log-analysis-beta/issues/3) with deleting the last project in the "Log Analysis Beta" menu.
+- Added confirmation prompt and prevented errors when no project is selected.
+
 ## 1.2.13
 
 - Modified the behavior to display the previous label when renaming Filters, Groups, or Projects.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/JeanTracker/log-analysis-beta.git"
   },
   "icon": "image/icon.png",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "engines": {
     "vscode": "^1.49.0"
   },
@@ -266,16 +266,17 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.49.0",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.27",
-    "eslint": "^7.6.0",
+    "@types/vscode": "^1.49.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
+    "eslint": "^7.6.0",
     "glob": "^7.1.6",
     "mocha": "^10.7.3",
     "typescript": "^4.0.2",
+    "vscode": "^1.1.37",
     "vscode-test": "^1.4.0"
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -376,6 +376,28 @@ export function editProject(treeItem: vscode.TreeItem, state: State, callback: (
     });
 }
 
+export async function handleLastProjectDeletion(treeItem: vscode.TreeItem, state: State) {
+  if (state.projects.length !== 1) {
+    deleteProject(treeItem, state);
+    return;
+  }
+
+  const userResponse = await vscode.window.showWarningMessage(
+    'This is the last item. Are you sure you want to delete it? If you delete it, an initialized NONAME project will be created.',
+    { modal: true },
+    'Yes',
+    'No'
+);
+
+  if (userResponse === 'Yes') {
+      vscode.window.showInformationMessage('Item deleted successfully.');
+      deleteProject(treeItem, state);
+      refreshSettings(state);
+    } else if (userResponse === 'No') {
+      vscode.window.showInformationMessage('Item deletion canceled.');
+  }
+}
+
 export function deleteProject(treeItem: vscode.TreeItem, state: State) {
   const selectedIndex = getProjectSelectedIndex(state.projects);
   const deleteIndex = state.projects.findIndex(project => (project.id === treeItem.id));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import {
   saveProject,
   addProject,
   editProject,
-  deleteProject,
+  handleLastProjectDeletion,
   refreshSettings,
   selectProject,
   updateExplorerTitle,
@@ -143,8 +143,13 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage('This command is excuted with button in Log Analysis Beta Projects');
         return;
       }
-      deleteProject(treeItem, state);
-      updateExplorerTitle(view, state);
+      handleLastProjectDeletion(treeItem, state)
+      .then(() => {
+        updateExplorerTitle(view, state);
+      })
+      .catch((err) => {
+          vscode.window.showErrorMessage(`Error: ${err.message}`);
+      });
     });
   context.subscriptions.push(disposableDeleteProject);
 


### PR DESCRIPTION
- Added a confirmation prompt when attempting to delete the last remaining project.
- Implemented logic to create and select a default `NONAME` project upon deletion of the last project.

Closes: https://github.com/JeanTracker/log-analysis-beta/issues/3